### PR TITLE
PR: with dark-flame-cs and fastn-io-typography

### DIFF
--- a/FASTN.ftd
+++ b/FASTN.ftd
@@ -11,6 +11,8 @@ favicon: /-/fastn-community.github.io/midnight-storm-ws/favicon.ico
 -- fastn.dependency: fastn-community.github.io/midnight-storm-cs
 -- fastn.dependency: fastn-community.github.io/midnight-storm-typography
 
+-- fastn.dependency: fastn-community.github.io/dark-flame-cs as cs
+-- fastn.dependency: fifthtry.github.io/fastn-io-typography as typo
 
 -- fastn.auto-import: theme
 -- fastn.auto-import: theme/common

--- a/FASTN/ws.ftd
+++ b/FASTN/ws.ftd
@@ -1,3 +1,5 @@
+-- import: cs
+-- import: typo
 -- import: fastn-community.github.io/midnight-storm-ws/tnc
 export: terms
 -- import: theme
@@ -60,6 +62,8 @@ breadcrumb: $page.breadcrumb
 login-button: $page.login-button
 logo-width: $page.logo-width
 logo-height: $page.logo-height
+colors: $cs.main
+types: $typo.types
 
 -- theme.page.footer:
 


### PR DESCRIPTION
With this PR we have added below color scheme and typography to this theme.
1. Color Schme: `fastn-community.github.io/dark-flame-cs`
2. Typography: `fifthtry.github.io/fastn-io-typography`